### PR TITLE
Release/1.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kxindot</groupId>
     <artifactId>goblin</artifactId>
-    <version>1.1.10-SNAPSHOT</version>
+    <version>1.1.10</version>
     <packaging>jar</packaging>
 
     <name>goblin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kxindot</groupId>
     <artifactId>goblin</artifactId>
-    <version>1.1.9</version>
+    <version>1.1.10-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>goblin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
+                            <waitUntil>validated</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/java/com/kxindot/goblin/Resources.java
+++ b/src/main/java/com/kxindot/goblin/Resources.java
@@ -1543,18 +1543,15 @@ public class Resources {
     	if (isFile(path)) {
     		delete(path);
 		} else if (isDirectory(path)) {
-			Stream<Path> list = null;
-			try {
-				list = Files.list(path);
+			try (Stream<Path> list = Files.list(path)) {
+				Iterator<Path> iterator = list.iterator();
+				while (iterator.hasNext()) {
+					deleteIfExists((Path) iterator.next());
+				}
+				delete(path);
 			} catch (IOException e) {
 				silentThrex(e);
 			}
-			Iterator<Path> iterator = list.iterator();
-			while (iterator.hasNext()) {
-				deleteIfExists((Path) iterator.next());
-			}
-			delete(path);
-			list.close();
 		}
     }
     

--- a/src/main/java/com/kxindot/goblin/resource/property/PropertyUtil.java
+++ b/src/main/java/com/kxindot/goblin/resource/property/PropertyUtil.java
@@ -70,8 +70,8 @@ public class PropertyUtil {
      */
     public static Properties loadProperties(InputStream in, boolean ordered) {
     	Properties properties = ordered ? new OrderedProperties() : new Properties();
-    	try {
-    		properties.load(in);
+    	try (InputStream input = in) {
+    		properties.load(input);
     	} catch (IOException e) {
     		silentThrex(e, "加载配置：读取字节输入流异常");
     	}


### PR DESCRIPTION
[修复：遍历目录Path失败时自动释放目录句柄](https://github.com/kxindot/goblin/pull/8/commits/083b19e63af2af1b770004e07481cbfa1dbcf578)
[修复：加载文件输入流失败时自动释放](https://github.com/kxindot/goblin/pull/8/commits/da3ca216f297bc40ad571d1630b6fd97538d494d)
[更新maven中央仓库发布配置：waitUntil配置值从published更改为validated](https://github.com/kxindot/goblin/pull/8/commits/be9d37b73edf2ecd333a8ceb7afff39a954926f6)